### PR TITLE
updated for assemblyscript v0.7.0

### DIFF
--- a/assembly/wasa.ts
+++ b/assembly/wasa.ts
@@ -255,7 +255,7 @@ export class Descriptor {
       while (load<u8>(path_buf + path_len) !== 0) {
         path_len++;
       }
-      return String.fromUTF8(path_buf, path_len);
+      return String.UTF8.decodeUnsafe(path_buf, path_len);
     }
   }
 
@@ -397,7 +397,7 @@ export class Descriptor {
     for (let i = 0; i < s_utf8_len; i++) {
       store<u8>(s_utf8_buf + i, s_utf8[i]);
     }
-    let s = String.fromUTF8(s_utf8_buf, s_utf8.length);
+    let s = String.UTF8.decodeUnsafe(s_utf8_buf, s_utf8.length);
 
     return s;
   }
@@ -677,7 +677,7 @@ export class FileSystem {
       if (offset + name_len > buf_used) {
         return null;
       }
-      let name = String.fromUTF8(buf + offset, name_len);
+      let name = String.UTF8.decodeUnsafe(buf + offset, name_len);
       out.push(name);
       offset += name_len;
     }
@@ -903,7 +903,7 @@ class StringUtils {
     while (load<u8>(cstring + size) !== 0) {
       size++;
     }
-    return String.fromUTF8(cstring, size);
+    return String.UTF8.decodeUnsafe(cstring, size);
   }
 }
 

--- a/assembly/wasa.ts
+++ b/assembly/wasa.ts
@@ -294,8 +294,8 @@ export class Descriptor {
       this.writeStringLn(s);
       return;
     }
-    let s_utf8_len: usize = s.lengthUTF8 - 1;
-    let s_utf8 = s.toUTF8();
+    let s_utf8_len: usize = String.UTF8.byteLength(s);
+    let s_utf8 = <usize>String.UTF8.encode(s);
     let iov = changetype<usize>(new ArrayBuffer(2 * sizeof<usize>()));
     store<u32>(iov, s_utf8);
     store<u32>(iov + sizeof<usize>(), s_utf8_len);
@@ -308,8 +308,8 @@ export class Descriptor {
    * @param s string
    */
   writeStringLn(s: string): void {
-    let s_utf8_len: usize = s.lengthUTF8 - 1;
-    let s_utf8 = s.toUTF8();
+    let s_utf8_len: usize = String.UTF8.byteLength(s);
+    let s_utf8 = <usize>String.UTF8.encode(s);
     let iov = changetype<usize>(new ArrayBuffer(4 * sizeof<usize>()));
     store<u32>(iov, s_utf8);
     store<u32>(iov + sizeof<usize>(), s_utf8_len);
@@ -470,8 +470,8 @@ export class FileSystem {
     }
     let fd_rights_inherited = fd_rights;
     let fd_flags: fdflags = 0;
-    let path_utf8_len: usize = path.lengthUTF8 - 1;
-    let path_utf8 = path.toUTF8();
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = changetype<usize>(String.UTF8.encode(path));
     let fd_buf = changetype<usize>(new ArrayBuffer(sizeof<u32>()));
     let res = path_open(
       dirfd as fd,
@@ -499,8 +499,8 @@ export class FileSystem {
    */
   static mkdir(path: string): bool {
     let dirfd = this.dirfdForPath(path);
-    let path_utf8_len: usize = path.lengthUTF8 - 1;
-    let path_utf8 = path.toUTF8();
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = <usize>String.UTF8.encode(path);
     let res = path_create_directory(dirfd, path_utf8, path_utf8_len);
 
     return res === errno.SUCCESS;
@@ -513,8 +513,8 @@ export class FileSystem {
    */
   static exists(path: string): bool {
     let dirfd = this.dirfdForPath(path);
-    let path_utf8_len: usize = path.lengthUTF8 - 1;
-    let path_utf8 = path.toUTF8();
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = <usize>String.UTF8.encode(path);
     let fd_lookup_flags = lookupflags.SYMLINK_FOLLOW;
     let st_buf = changetype<usize>(new ArrayBuffer(56));
     let res = path_filestat_get(dirfd, fd_lookup_flags, path_utf8, path_utf8_len,
@@ -531,11 +531,11 @@ export class FileSystem {
    */
   static link(old_path: string, new_path: string): bool {
     let old_dirfd = this.dirfdForPath(old_path);
-    let old_path_utf8_len: usize = old_path.lengthUTF8 - 1;
-    let old_path_utf8 = old_path.toUTF8();
+    let old_path_utf8_len: usize = String.UTF8.byteLength(old_path);
+    let old_path_utf8 = <usize>String.UTF8.encode(old_path);
     let new_dirfd = this.dirfdForPath(new_path);
-    let new_path_utf8_len: usize = new_path.lengthUTF8 - 1;
-    let new_path_utf8 = new_path.toUTF8();
+    let new_path_utf8_len: usize = String.UTF8.byteLength(new_path);
+    let new_path_utf8 = <usize>String.UTF8.encode(new_path);
     let fd_lookup_flags = lookupflags.SYMLINK_FOLLOW;
     let res = path_link(old_dirfd, fd_lookup_flags, old_path_utf8, old_path_utf8_len,
       new_dirfd, new_path_utf8, new_path_utf8_len);
@@ -550,11 +550,11 @@ export class FileSystem {
    * @returns `true` on success, `false` on failure
    */
   static symlink(old_path: string, new_path: string): bool {
-    let old_path_utf8_len: usize = old_path.lengthUTF8 - 1;
-    let old_path_utf8 = old_path.toUTF8();
+    let old_path_utf8_len: usize = String.UTF8.byteLength(old_path);
+    let old_path_utf8 = <usize>String.UTF8.encode(old_path);
     let new_dirfd = this.dirfdForPath(new_path);
-    let new_path_utf8_len: usize = new_path.lengthUTF8 - 1;
-    let new_path_utf8 = new_path.toUTF8();
+    let new_path_utf8_len: usize = String.UTF8.byteLength(new_path);
+    let new_path_utf8 = <usize>String.UTF8.encode(new_path);
     let res = path_symlink(old_path_utf8, old_path_utf8_len,
       new_dirfd, new_path_utf8, new_path_utf8_len);
 
@@ -568,8 +568,8 @@ export class FileSystem {
    */
   static unlink(path: string): bool {
     let dirfd = this.dirfdForPath(path);
-    let path_utf8_len: usize = path.lengthUTF8 - 1;
-    let path_utf8 = path.toUTF8();
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = <usize>String.UTF8.encode(path);
     let res = path_unlink_file(dirfd, path_utf8, path_utf8_len);
 
     return res === errno.SUCCESS;
@@ -582,8 +582,8 @@ export class FileSystem {
    */
   static rmdir(path: string): bool {
     let dirfd = this.dirfdForPath(path);
-    let path_utf8_len: usize = path.lengthUTF8 - 1;
-    let path_utf8 = path.toUTF8();
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = <usize>String.UTF8.encode(path);
     let res = path_remove_directory(dirfd, path_utf8, path_utf8_len);
 
     return res === errno.SUCCESS;
@@ -596,8 +596,8 @@ export class FileSystem {
    */
   static stat(path: string): FileStat {
     let dirfd = this.dirfdForPath(path);
-    let path_utf8_len: usize = path.lengthUTF8 - 1;
-    let path_utf8 = path.toUTF8();
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = String.UTF8.encode(path);
     let fd_lookup_flags = lookupflags.SYMLINK_FOLLOW;
     let st_buf = changetype<usize>(new ArrayBuffer(56));
     if (path_filestat_get(dirfd, fd_lookup_flags, path_utf8, path_utf8_len, changetype<filestat>(st_buf)) !== errno.SUCCESS) {
@@ -613,8 +613,8 @@ export class FileSystem {
    */
   static lstat(path: string): FileStat {
     let dirfd = this.dirfdForPath(path);
-    let path_utf8_len: usize = path.lengthUTF8 - 1;
-    let path_utf8 = path.toUTF8();
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = <usize>String.UTF8.encode(path);
     let fd_lookup_flags = 0;
     let st_buf = changetype<usize>(new ArrayBuffer(56));
     if (path_filestat_get(dirfd, fd_lookup_flags, path_utf8, path_utf8_len, changetype<filestat>(st_buf)) !== errno.SUCCESS) {
@@ -631,11 +631,11 @@ export class FileSystem {
    */
   static rename(old_path: string, new_path: string): bool {
     let old_dirfd = this.dirfdForPath(old_path);
-    let old_path_utf8_len: usize = old_path.lengthUTF8 - 1;
-    let old_path_utf8 = old_path.toUTF8();
+    let old_path_utf8_len: usize = String.UTF8.byteLength(old_path);
+    let old_path_utf8 = <usize>String.UTF8.encode(old_path);
     let new_dirfd = this.dirfdForPath(new_path);
-    let new_path_utf8_len: usize = new_path.lengthUTF8 - 1;
-    let new_path_utf8 = new_path.toUTF8();
+    let new_path_utf8_len: usize = String.UTF8.byteLength(new_path);
+    let new_path_utf8 = <usize>String.UTF8.encode(new_path);
     let res = path_rename(old_dirfd, old_path_utf8, old_path_utf8_len,
       new_dirfd, new_path_utf8, new_path_utf8_len);
 


### PR DESCRIPTION
The string encoding API has changed a bit so `toUTF8` and `.lengthUTF8` are deprecated.

I've done some manual testing and things seem to work, but if something doesn't look right, let me know!